### PR TITLE
Fix Signature Verification in case of IOS MDM Signature

### DIFF
--- a/commandment/cms/__init__.py
+++ b/commandment/cms/__init__.py
@@ -1,7 +1,12 @@
-from typing import Union, Optional, Type
-from asn1crypto.cms import CertificateSet, SignerIdentifier, Certificate, SignedDigestAlgorithm, DigestAlgorithm
+from base64 import b64encode
+from typing import Union, Optional, Type, Any
+from asn1crypto.cms import CertificateSet, SignerIdentifier, Certificate, SignedDigestAlgorithm, DigestAlgorithm, CMSAttributes
+from asn1crypto.core import Sequence
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
+from flask import current_app
 
 
 def _certificate_by_signer_identifier(certificates: CertificateSet, sid: SignerIdentifier) -> Optional[Certificate]:
@@ -72,3 +77,69 @@ def _cryptography_pad_function(algorithm: SignedDigestAlgorithm) -> Union[None, 
         return padding.PKCS1v15
     else:
         return None
+
+
+class CMSSignedAttributeStruct(Sequence):
+    _fields = [
+        ('A', CMSAttributes)
+    ]
+
+
+def clean_cms_signed_attributes(attributes: CMSAttributes) -> bytes:
+    """
+    This utility removes the leading sequence octets from signed attributes
+    mimics https://github.com/mozilla-services/pkcs7/blob/3a1db52591c76b9c21a6fb04c0404519b7bddfa7/sign.go#L75
+    :param attributes: CMSAttributes
+    :return: bytes
+    """
+    return CMSSignedAttributeStruct({"A": attributes})["A"].dump()
+
+
+def _get_signed_attribute(attributes: CMSAttributes, attribute_name: str) -> Any:
+    """
+    Find and return an attribute value of type 'attribute_name' from attributes
+    :param attributes: CMSAttributes Signed Attributes
+    :param attribute_name: string Attribute name to look for
+    :return: Any
+    """
+    for i in range(0, len(attributes)):
+        signed_attr = attributes[i]
+        if signed_attr['type'].native == attribute_name:
+            return signed_attr['values'][0].native
+
+
+def _verify_signature_digest(attributes: CMSAttributes, data: bytes, hash_fn: hashes.HashAlgorithm):
+    """
+    Computes digest of data according to 'hash_fn' and matches it with the digest in signed 'attributes'.
+    :param attributes: CMSAttributes Signed Attributes
+    :param data: bytes Data that is signed
+    :param hash_fn: Hashes.Algorithm hash function used to compute the hash
+    :return: None raise exception on signature mismatch
+    """
+    message_digest = _get_signed_attribute(attributes, "message_digest")
+    if not message_digest:
+        raise InvalidSignature("Message digest not found in signature attributes.")
+    current_app.logger.debug("SignerInfo digest: %s", b64encode(message_digest))
+    digest = hashes.Hash(hash_fn, default_backend())
+    digest.update(data)
+    computed_hash = digest.finalize()
+    if computed_hash != message_digest:
+        raise InvalidSignature("Siganture digest {} and Computed digest {} do not match.".format(b64encode(message_digest),
+                                                                                                 b64encode(computed_hash)))
+
+
+def _verify_signature_time(attributes: CMSAttributes, certificate: Certificate):
+    """
+    Checks the validity of signature.
+    :param attributes: CMSAttributes Signed Attributes
+    :param certificate: cms.Certificate
+    :return: None raise exception if signature time is out of certificate validity.
+    """
+    signature_time = _get_signed_attribute(attributes, "signing_time")
+    if signature_time is None:
+        raise InvalidSignature("Signing time not found in signature attributes.")
+    validity = certificate["tbs_certificate"]["validity"]
+    if signature_time < validity["not_before"].native or signature_time > validity["not_after"].native:
+        raise InvalidSignature("Signing time {} is outside of certificate validity {} to {}".format(signature_time,
+                                                                                                    validity["not_before"].native,
+                                                                                                    validity["not_after"].native))


### PR DESCRIPTION
MDM signature verification fails in case of IOS.

fixes issue https://github.com/cmdmnt/commandment/issues/18

micromdm uses [pkcs7](https://github.com/mozilla-services/pkcs7/)
Follow the protocol as used in pkcs7 library specifically this code (https://github.com/mozilla-services/pkcs7/blob/master/verify.go)
